### PR TITLE
Contacts refactor

### DIFF
--- a/signal_client/src/functions/accounts.rs
+++ b/signal_client/src/functions/accounts.rs
@@ -1,3 +1,4 @@
+use presage::manager::Registered;
 use qrcodegen::QrCode;
 use qrcodegen::QrCodeEcc;
 use futures::channel::oneshot;
@@ -6,6 +7,8 @@ use presage::manager::Manager;
 use presage::libsignal_service::configuration::SignalServers;
 use presage_store_sled::{MigrationConflictStrategy, OnNewIdentity, SledStore};
 use std::error::Error;
+
+use super::paths;
 
 
 pub fn generate_qr_code(text: &str) {
@@ -55,4 +58,10 @@ pub async fn link_account(arguments: Vec<String>) -> Result<(), Box<dyn Error>> 
         },
     ).await;
     Ok(())
+}
+
+// Wrapper function to load registered user into a manager
+pub async fn load_registered_user() -> Result<Manager<SledStore, Registered>, Box<dyn std::error::Error>> {
+    let store = SledStore::open(paths::DATABASE, MigrationConflictStrategy::BackupAndDrop, OnNewIdentity::Trust)?;
+    Ok(Manager::load_registered(store).await?)
 }

--- a/signal_client/src/functions/mod.rs
+++ b/signal_client/src/functions/mod.rs
@@ -3,3 +3,4 @@ pub mod contacts;
 pub mod sending;
 pub mod received;
 mod messages;
+mod paths;

--- a/signal_client/src/functions/paths.rs
+++ b/signal_client/src/functions/paths.rs
@@ -1,0 +1,1 @@
+pub const DATABASE: &str = "./registration/main";

--- a/signal_client/src/functions/paths.rs
+++ b/signal_client/src/functions/paths.rs
@@ -1,1 +1,2 @@
 pub const DATABASE: &str = "./registration/main";
+pub const CONTACTS: &str = "./registration/contacts.json";

--- a/signal_client/src/functions/received.rs
+++ b/signal_client/src/functions/received.rs
@@ -2,7 +2,7 @@ use std::ops::RangeFull;
 use futures::StreamExt;
 use presage::libsignal_service::content::ContentBody;
 use presage::Manager;
-use presage::manager::ReceivingMode;
+use presage::manager::{ReceivingMode, Registered};
 use presage::store::Thread;
 use presage_store_sled::{MigrationConflictStrategy, OnNewIdentity, SledStore};
 use crate::functions::contacts::{find_account_uuid};
@@ -44,10 +44,11 @@ pub async fn show_messages(arguments: Vec<String>) -> Result<(), Box<dyn std::er
     Ok(())
 }
 
-pub async fn show_last_message(contact: &String, store: &SledStore) -> Result<(), Box<dyn std::error::Error>> {
+// Function to show most recent message for given contact
+pub fn show_last_message(contact: &String, manager: &Manager<SledStore, Registered>) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(uuid) = find_account_uuid(contact) {
         // let store = SledStore::open("./registration/main", MigrationConflictStrategy::BackupAndDrop, OnNewIdentity::Trust)?;
-        let manager = Manager::load_registered(store.clone()).await?;
+        // let manager = Manager::load_registered(store.clone()).await?;
         let thread = Thread::Contact(uuid);
         let messages = manager.messages(&thread, RangeFull)?;
 


### PR DESCRIPTION
Refaktoryzacja przede wszystkim modułu contacts, polegająca na rozbiciu rozbudowanych funkcji na mniejsze składowe (dzięki temu łatwiej będzie pisać pod to unit testy). Duże funkcje nie spełniały SRP (odpowiadały jednocześnie za synchronizację i wypisywanie kontaktów)