### PR TITLE
Added `uninlined_format_args` to CI

### DIFF
--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-Dwarnings"
+  RUSTFLAGS: "-Dwarnings -Dclippy::uninlined_format_args"
 
 permissions:
   contents: write


### PR DESCRIPTION
It's enabled in rust version `1.88` and not enabled in `1.89`. CI has `1.88`, so default clippy won't run show any warnings, but CI will fail