### PR TITLE
Adjusted manager multithreading

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,10 +4,7 @@ use crate::messages::send::{send_attachment_tui, send_message_tui};
 use crate::paths::QRCODE;
 use crate::profile::get_profile_tui;
 use crate::ui::render_ui;
-use crate::{
-    AsyncContactsMap, AsyncRegisteredManager, config::Config, contacts, create_registered_manager,
-    devices,
-};
+use crate::{AsyncContactsMap, config::Config, contacts, create_registered_manager, devices};
 use anyhow::{Error, Result};
 use crossterm::event::{self, Event, KeyModifiers};
 use crossterm::event::{KeyCode, KeyEventKind};
@@ -26,7 +23,7 @@ use std::sync::Arc;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::{fs, io};
 use tokio::runtime::Builder;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::Mutex;
 use tracing::error;
 
 use image::ImageFormat;
@@ -99,7 +96,7 @@ pub struct App {
     pub config: Config,
     pub config_selected: usize,
 
-    pub manager: Option<AsyncRegisteredManager>,
+    pub manager: Option<Manager<SqliteStore, Registered>>,
 
     pub tx_thread: mpsc::Sender<EventApp>,
     pub rx_tui: mpsc::Receiver<EventApp>,
@@ -185,18 +182,17 @@ impl App {
     ) -> io::Result<bool> {
         if self.linking_status == LinkingStatus::Linked {
             if let Some(rx) = self.rx_thread.take() {
-                let new_manager: AsyncRegisteredManager = match create_registered_manager().await {
-                    Ok(manager) => Arc::new(RwLock::new(manager)),
+                let new_manager = match create_registered_manager().await {
+                    Ok(manager) => manager,
                     Err(_) => {
                         return Err(io::Error::other("Failed to create manager"));
                     }
                 };
-                let new_manager_mutex = Arc::clone(&new_manager);
 
-                self.manager = Some(new_manager);
+                self.manager = Some(new_manager.clone());
 
                 if let Err(e) =
-                    init_background_threads(self.tx_thread.clone(), rx, new_manager_mutex).await
+                    init_background_threads(self.tx_thread.clone(), rx, new_manager).await
                 {
                     eprintln!("Failed to init threads: {e:?}");
                 }
@@ -318,25 +314,21 @@ impl App {
                     true => {
                         self.linking_status = LinkingStatus::Linked;
                         if let Some(rx) = self.rx_thread.take() {
-                            let new_manager: AsyncRegisteredManager = match manager_optional {
-                                Some(manager) => Arc::new(RwLock::new(manager)),
+                            let new_manager = match manager_optional {
+                                Some(manager) => manager,
                                 None => match create_registered_manager().await {
-                                    Ok(manager) => Arc::new(RwLock::new(manager)),
+                                    Ok(manager) => manager,
                                     Err(_) => {
                                         return Err(io::Error::other("Failed to create manager"));
                                     }
                                 },
                             };
-                            let new_manager_mutex = Arc::clone(&new_manager);
 
-                            self.manager = Some(new_manager);
+                            self.manager = Some(new_manager.clone());
 
-                            if let Err(e) = init_background_threads(
-                                self.tx_thread.clone(),
-                                rx,
-                                new_manager_mutex,
-                            )
-                            .await
+                            if let Err(e) =
+                                init_background_threads(self.tx_thread.clone(), rx, new_manager)
+                                    .await
                             {
                                 eprintln!("Failed to init threads: {e:?}");
                             }
@@ -660,15 +652,14 @@ fn is_connection_error(e: &Error) -> bool {
 pub async fn init_background_threads(
     tx_thread: mpsc::Sender<EventApp>,
     rx_thread: mpsc::Receiver<EventSend>,
-    manager: AsyncRegisteredManager,
+    mut manager: Manager<SqliteStore, Registered>,
 ) -> Result<()> {
-    let new_manager_mutex = Arc::clone(&manager);
     let current_contacts_mutex: AsyncContactsMap =
-        Arc::new(Mutex::new(get_contacts_tui(new_manager_mutex).await?));
+        Arc::new(Mutex::new(get_contacts_tui(&mut manager).await?));
 
     //spawn thread to sync contacts and new messages
     let tx_synchronization_events = tx_thread.clone();
-    let new_manager = Arc::clone(&manager);
+    let new_manager = manager.clone();
     let new_contacts = Arc::clone(&current_contacts_mutex);
     thread::Builder::new()
         .name(String::from("synchronization_thread"))
@@ -686,7 +677,7 @@ pub async fn init_background_threads(
         .unwrap();
 
     //spawn thread to receive background events
-    let new_manager = Arc::clone(&manager);
+    let new_manager = manager.clone();
     let rx_sending_thread = rx_thread;
     let new_contacts = Arc::clone(&current_contacts_mutex);
     let tx_status_clone = tx_thread.clone();
@@ -712,8 +703,8 @@ pub async fn init_background_threads(
         .unwrap();
 
     // Add profile fetching
-    let profile_manager_1 = Arc::clone(&manager);
-    let profile_manager_2 = Arc::clone(&manager);
+    let mut profile_manager_1 = manager.clone();
+    let mut profile_manager_2 = manager.clone();
     let tx_profile = tx_thread.clone();
     thread::Builder::new()
         .name(String::from("profile_thread"))
@@ -725,11 +716,11 @@ pub async fn init_background_threads(
                 .build()
                 .unwrap();
             runtime.block_on(async move {
-                if let Ok(profile) = get_profile_tui(Arc::from(profile_manager_1)).await {
+                if let Ok(profile) = get_profile_tui(&mut profile_manager_1).await {
                     let _ = tx_profile.send(EventApp::ProfileReceived(profile));
                 }
                 if let Ok(Some(avatar_data)) =
-                    crate::profile::get_my_profile_avatar_tui(Arc::from(profile_manager_2)).await
+                    crate::profile::get_my_profile_avatar_tui(&mut profile_manager_2).await
                 {
                     let _ = tx_profile.send(EventApp::AvatarReceived(avatar_data));
                 }
@@ -765,21 +756,18 @@ pub fn handle_input_events(tx: mpsc::Sender<EventApp>) {
 
 pub async fn handle_synchronization(
     tx: mpsc::Sender<EventApp>,
-    manager_mutex: AsyncRegisteredManager,
+    mut manager: Manager<SqliteStore, Registered>,
     current_contacts_mutex: AsyncContactsMap,
 ) {
-    let mut manager = manager_mutex.write().await;
     match contacts::initial_sync(&mut manager).await {
         Ok(_) => {}
         Err(e) => error!("Initial contact sync failed: {e}"),
     }
-    drop(manager);
     let mut previous_contacts: Vec<(String, String)> = Vec::new();
     loop {
-        let new_mutex = Arc::clone(&manager_mutex);
         let new_contacts_mutex = Arc::clone(&current_contacts_mutex);
 
-        let messages = match receive::receive_messages_tui(new_mutex, new_contacts_mutex).await {
+        let messages = match receive::receive_messages_tui(&mut manager, new_contacts_mutex).await {
             Ok(list) => {
                 let _ = tx.send(EventApp::NetworkStatusChanged(NetworkStatus::Connected));
                 list
@@ -794,8 +782,7 @@ pub async fn handle_synchronization(
             }
         };
 
-        let new_mutex = Arc::clone(&manager_mutex);
-        let result = contacts::list_contacts_tui(new_mutex).await;
+        let result = contacts::list_contacts_tui(&mut manager).await;
 
         let contacts = match result {
             Ok(list) => list,
@@ -907,7 +894,7 @@ pub async fn handle_synchronization(
 
 pub async fn handle_background_events(
     rx: Receiver<EventSend>,
-    manager_mutex: AsyncRegisteredManager,
+    mut manager: Manager<SqliteStore, Registered>,
     current_contacts_mutex: AsyncContactsMap,
     tx_status: mpsc::Sender<EventApp>,
 ) {
@@ -918,7 +905,7 @@ pub async fn handle_background_events(
                     match send_message_tui(
                         recipient.clone(),
                         text.clone(),
-                        Arc::clone(&manager_mutex),
+                        manager.clone(),
                         Arc::clone(&current_contacts_mutex),
                     )
                     .await
@@ -941,7 +928,7 @@ pub async fn handle_background_events(
                     }
 
                     let _ = contacts::sync_contacts_tui(
-                        Arc::clone(&manager_mutex),
+                        &mut manager,
                         Arc::clone(&current_contacts_mutex),
                     )
                     .await;
@@ -951,7 +938,7 @@ pub async fn handle_background_events(
                         recipient.clone(),
                         text.clone(),
                         attachment_path,
-                        Arc::clone(&manager_mutex),
+                        &mut manager,
                         Arc::clone(&current_contacts_mutex),
                     )
                     .await
@@ -974,15 +961,14 @@ pub async fn handle_background_events(
                     }
 
                     let _ = contacts::sync_contacts_tui(
-                        Arc::clone(&manager_mutex),
+                        &mut manager,
                         Arc::clone(&current_contacts_mutex),
                     )
                     .await;
                 }
                 EventSend::GetMessagesForContact(uuid_str) => {
-                    let new_mutex = Arc::clone(&manager_mutex);
                     let result =
-                        list_messages_tui(uuid_str.clone(), "0".to_string(), new_mutex).await;
+                        list_messages_tui(uuid_str.clone(), "0".to_string(), &mut manager).await;
                     let messages = match result {
                         Ok(list) => {
                             let _ = tx_status

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -1,4 +1,3 @@
-use crate::AsyncRegisteredManager;
 use crate::messages::receive::receiving_loop;
 use crate::{AsyncContactsMap, create_registered_manager};
 use anyhow::Result;
@@ -42,11 +41,10 @@ pub async fn sync_contacts_cli() -> Result<()> {
 
 /// Function to sync contacts when TUI is used
 pub async fn sync_contacts_tui(
-    manager_mutex: AsyncRegisteredManager,
+    manager: &mut Manager<SqliteStore, Registered>,
     current_contacts_mutex: AsyncContactsMap,
 ) -> Result<()> {
-    let mut manager = manager_mutex.write().await;
-    sync_contacts(&mut manager, current_contacts_mutex).await
+    sync_contacts(manager, current_contacts_mutex).await
 }
 
 async fn get_contacts(
@@ -71,10 +69,9 @@ pub async fn get_contacts_cli(
 }
 
 pub async fn get_contacts_tui(
-    manager_mutex: AsyncRegisteredManager,
+    manager: &mut Manager<SqliteStore, Registered>,
 ) -> Result<HashMap<Uuid, Contact>> {
-    let manager = manager_mutex.read().await;
-    get_contacts(&manager).await
+    get_contacts(manager).await
 }
 
 async fn list_contacts(
@@ -91,8 +88,7 @@ pub async fn list_contacts_cli() -> Result<Vec<Result<Contact, SqliteStoreError>
 
 /// Returns iterator over stored contacts, for use in TUI
 pub async fn list_contacts_tui(
-    manager_mutex: AsyncRegisteredManager,
+    manager: &mut Manager<SqliteStore, Registered>,
 ) -> Result<Vec<Result<Contact, SqliteStoreError>>> {
-    let manager = manager_mutex.read().await;
-    list_contacts(&manager).await
+    list_contacts(manager).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use presage::{
 use presage_store_sqlite::{SqliteConnectOptions, SqliteStore, SqliteStoreError};
 use std::sync::Arc;
 use std::{collections::HashMap, str::FromStr};
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::Mutex;
 
 pub mod app;
 pub mod args;
@@ -24,8 +24,6 @@ pub mod tui;
 pub mod ui;
 
 pub mod sending {}
-
-pub type AsyncRegisteredManager = Arc<RwLock<Manager<SqliteStore, Registered>>>;
 
 pub type AsyncContactsMap = Arc<Mutex<HashMap<Uuid, Contact>>>;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use signal_client::logger::init_logger;
 use signal_client::messages;
 use signal_client::{cli, contacts, devices, tui};
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     init_logger();
     let cli = Cli::parse();

--- a/src/messages/send.rs
+++ b/src/messages/send.rs
@@ -17,7 +17,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
-use tracing::error;
 
 /// finds contact uuid from string that can be contact_name or contact phone_number
 pub async fn find_uuid(
@@ -70,7 +69,6 @@ async fn send(
     data_message: DataMessage,
     timestamp: u64,
 ) -> Result<()> {
-    error!("HERE");
     manager
         .send_message(recipient_addr, data_message, timestamp)
         .await
@@ -96,10 +94,10 @@ async fn send_message(
 pub async fn send_message_tui(
     recipient: String,
     text_message: String,
-    mut manager: Manager<SqliteStore, Registered>,
+    manager: &mut Manager<SqliteStore, Registered>,
 ) -> Result<()> {
     // let mut manager = create_registered_manager().await?;
-    send_message(&mut manager, recipient, text_message).await
+    send_message(manager, recipient, text_message).await
 }
 
 /// sends text message to recipient ( phone number or name ), for usage with CLI

--- a/src/messages/send.rs
+++ b/src/messages/send.rs
@@ -1,6 +1,6 @@
 use crate::contacts::get_contacts_cli;
 use crate::messages::receive::receiving_loop;
-use crate::{AsyncContactsMap, AsyncRegisteredManager, create_registered_manager};
+use crate::{AsyncContactsMap, create_registered_manager};
 use anyhow::Result;
 use mime_guess::mime::APPLICATION_OCTET_STREAM;
 use presage::Manager;
@@ -98,11 +98,10 @@ async fn send_message(
 pub async fn send_message_tui(
     recipient: String,
     text_message: String,
-    manager_mutex: AsyncRegisteredManager,
+    mut manager: Manager<SqliteStore, Registered>,
     current_contacts_mutex: AsyncContactsMap,
 ) -> Result<()> {
     // let mut manager = create_registered_manager().await?;
-    let mut manager = manager_mutex.write().await;
     send_message(
         &mut manager,
         recipient,
@@ -210,12 +209,11 @@ pub async fn send_attachment_tui(
     recipient: String,
     text_message: String,
     attachment_path: String,
-    manager_mutex: AsyncRegisteredManager,
+    manager: &mut Manager<SqliteStore, Registered>,
     current_contacts_mutex: AsyncContactsMap,
 ) -> Result<()> {
-    let mut manager = manager_mutex.write().await;
     send_attachment(
-        &mut manager,
+        manager,
         recipient,
         text_message,
         attachment_path,

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,10 +1,9 @@
-use crate::{AsyncRegisteredManager, create_registered_manager};
+use crate::create_registered_manager;
 use anyhow::Result;
-use presage::libsignal_service::Profile;
-use std::sync::Arc;
+use presage::{Manager, libsignal_service::Profile, manager::Registered};
+use presage_store_sqlite::SqliteStore;
 
-pub async fn get_profile_tui(manager_mutex: Arc<AsyncRegisteredManager>) -> Result<Profile> {
-    let mut manager = manager_mutex.write().await;
+pub async fn get_profile_tui(manager: &mut Manager<SqliteStore, Registered>) -> Result<Profile> {
     manager.retrieve_profile().await.map_err(anyhow::Error::new)
 }
 
@@ -33,10 +32,8 @@ pub async fn get_my_profile_avatar_cli() -> Result<Option<Vec<u8>>> {
 }
 
 pub async fn get_my_profile_avatar_tui(
-    manager_mutex: Arc<AsyncRegisteredManager>,
+    manager: &mut Manager<SqliteStore, Registered>,
 ) -> Result<Option<Vec<u8>>> {
-    let mut manager = manager_mutex.write().await;
-
     let registration_data = manager.registration_data();
     let profile_key = registration_data.profile_key();
 


### PR DESCRIPTION
This is a base to fix our problem with async. It still does not work perfectly, but much better than it did before.

What was changed:
- `AsyncRegisteredManager` type was removed. `Manager` is `Sync` and `Send` so it is safe to pass it between threads.
- Receiving loop was removed from `send_message()`