### PR TITLE
Storage paths for `release` profile.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@ use crate::contacts::get_contacts_tui;
 use crate::messages::attachments::save_attachment;
 use crate::messages::receive::{self, MessageDto, check_contacts, contact, format_message};
 use crate::messages::send;
-use crate::paths::{ACCOUNTS_DIR, QRCODE};
+use crate::paths;
 use crate::profile::get_profile_tui;
 use crate::ui::render_ui;
 use crate::{AsyncContactsMap, config::Config, contacts, groups};
@@ -489,7 +489,7 @@ impl App {
     pub async fn delete_account(&mut self, account_name: String) -> Result<()> {
         use std::path::Path;
         let is_current = self.current_account.as_ref() == Some(&account_name);
-        let account_dir = format!("{ACCOUNTS_DIR}/{account_name}");
+        let account_dir = format!("{}/{account_name}", paths::accounts_dir());
         if Path::new(&account_dir).exists() {
             std::fs::remove_dir_all(&account_dir)?;
         }
@@ -1180,8 +1180,8 @@ impl App {
 
                     self.creating_account_name = Some(account_name.clone());
 
-                    if Path::new(QRCODE).exists() {
-                        let _ = fs::remove_file(QRCODE);
+                    if Path::new(&paths::qrcode()).exists() {
+                        let _ = fs::remove_file(paths::qrcode());
                     }
 
                     let tx_qr = self.tx_thread.clone();
@@ -1373,8 +1373,8 @@ impl App {
                                     self.textarea.trim().to_string()
                                 };
 
-                                if Path::new(QRCODE).exists() {
-                                    fs::remove_file(QRCODE)?;
+                                if Path::new(&paths::qrcode()).exists() {
+                                    fs::remove_file(paths::qrcode())?;
                                 }
 
                                 let tx_key_events = self.tx_thread.clone();
@@ -1736,8 +1736,8 @@ pub async fn handle_linking_device_for_account(
                 warn!("Failed to save config: {e:?}");
             }
 
-            if Path::new(QRCODE).exists() {
-                match fs::remove_file(QRCODE) {
+            if Path::new(&paths::qrcode()).exists() {
+                match fs::remove_file(paths::qrcode()) {
                     Ok(_) => {}
                     Err(e) => error!("Failed to remove file with QR code: {e}"),
                 }
@@ -1751,8 +1751,8 @@ pub async fn handle_linking_device_for_account(
             }
         }
         Err(e) => {
-            if Path::new(QRCODE).exists() {
-                match fs::remove_file(QRCODE) {
+            if Path::new(&paths::qrcode()).exists() {
+                match fs::remove_file(paths::qrcode()) {
                     Ok(_) => {}
                     Err(e) => error!("Failed to remove file with QR code: {e}"),
                 }
@@ -2793,7 +2793,7 @@ async fn handle_get_group_info_event(
 
 pub fn handle_checking_qr_code(tx: mpsc::Sender<EventApp>) {
     loop {
-        if Path::new(QRCODE).exists() {
+        if Path::new(&paths::qrcode()).exists() {
             if tx.send(EventApp::QrCodeGenerated).is_err() {
                 error!("Failed to send QrCodeGenerated event");
             }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,10 +1,45 @@
-use std::env;
+use anyhow::Result;
+use std::{
+    env::{self, home_dir},
+    fs,
+    path::Path,
+    sync::OnceLock,
+};
 
 use tracing::level_filters::LevelFilter;
 use tracing_appender::rolling;
 use tracing_subscriber::{EnvFilter, fmt::writer::BoxMakeWriter};
 
 use crate::env::{SIGNAL_LOGGER_LEVEL, SIGNAL_ONSCREEN_LOGGER};
+
+fn ensure_local_state(home_dir: &Path) -> Result<()> {
+    if !fs::exists(home_dir.join(".local/state"))? {
+        fs::create_dir_all(home_dir.join(".local/state"))?;
+    }
+    Ok(())
+}
+
+fn logs_directory() -> String {
+    static PATH: OnceLock<String> = OnceLock::new();
+    PATH.get_or_init(|| {
+        if cfg!(debug_assertions) {
+            "./signal_client/logs".to_string()
+        } else {
+            match home_dir() {
+                Some(home_dir) => match ensure_local_state(&home_dir) {
+                    Ok(_) => home_dir
+                        .join(".local/state/signal_client/logs")
+                        .to_str()
+                        .unwrap_or("./signal_client/logs")
+                        .to_string(),
+                    Err(_) => "./signal_client/logs".to_string(),
+                },
+                None => "./signal_client/logs".to_string(),
+            }
+        }
+    })
+    .into()
+}
 
 pub fn init_logger() {
     let filter = EnvFilter::builder()
@@ -20,7 +55,7 @@ pub fn init_logger() {
             .with_ansi(true)
             .init();
     } else {
-        let file_writer = rolling::hourly("logs", "signal_client.log");
+        let file_writer = rolling::hourly(logs_directory(), "signal_client.log");
         let (non_blocking, _guard) = tracing_appender::non_blocking(file_writer);
 
         tracing_subscriber::fmt()

--- a/src/messages/send/group.rs
+++ b/src/messages/send/group.rs
@@ -84,10 +84,7 @@ async fn send_message(
     let data_message = create_data_message(text_message, &master_key, timestamp, quoted_message);
 
     let send_result = send(manager, &master_key, data_message, timestamp).await;
-    if let Err(e) = send_result {
-        error!("{e}");
-    }
-    Ok(())
+    send_result
 }
 
 async fn send_delete_message(

--- a/src/messages/send/group.rs
+++ b/src/messages/send/group.rs
@@ -83,8 +83,7 @@ async fn send_message(
 
     let data_message = create_data_message(text_message, &master_key, timestamp, quoted_message);
 
-    let send_result = send(manager, &master_key, data_message, timestamp).await;
-    send_result
+    send(manager, &master_key, data_message, timestamp).await
 }
 
 async fn send_delete_message(

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,7 +1,116 @@
-pub const STORE: &str = "sqlite://store.db";
+use std::env::home_dir;
+use std::fs;
+use std::path::Path;
+use std::sync::OnceLock;
 
-pub const QRCODE: &str = "./assets/qrcode";
-
-pub const ASSETS: &str = "./assets";
+use anyhow::Result;
+use tracing::error;
 
 pub const ACCOUNTS_DIR: &str = "accounts";
+
+fn ensure_local_share_dir(home_dir: &Path) -> Result<()> {
+    if !fs::exists(home_dir.join(".local/share"))? {
+        fs::create_dir_all(home_dir.join(".local/share"))?;
+    }
+    Ok(())
+}
+
+pub fn store() -> String {
+    static PATH: OnceLock<String> = OnceLock::new();
+    PATH.get_or_init(|| {
+        if cfg!(debug_assertions) {
+            "sqlite://store.db".to_string()
+        } else {
+            match home_dir() {
+                Some(home_dir) => match ensure_local_share_dir(&home_dir) {
+                    Ok(_) => home_dir
+                        .join(".local/share/signal_client/store.db")
+                        .to_str()
+                        .unwrap_or("sqlite://store.db")
+                        .to_string(),
+                    Err(error) => {
+                        error!(%error, "Unable to ensure if ~/.local/share directory exists.");
+                        "sqlite://store.db".to_string()
+                    }
+                },
+                None => "sqlite://store.db".to_string(),
+            }
+        }
+    })
+    .into()
+}
+
+pub fn qrcode() -> String {
+    static PATH: OnceLock<String> = OnceLock::new();
+    PATH.get_or_init(|| {
+        if cfg!(debug_assertions) {
+            "./assets/qrcode".to_string()
+        } else {
+            match home_dir() {
+                Some(home_dir) => match ensure_local_share_dir(&home_dir) {
+                    Ok(_) => home_dir
+                        .join(".local/share/signal_client/assets/qrcode")
+                        .to_str()
+                        .unwrap_or("./assets/qrcode")
+                        .to_string(),
+                    Err(error) => {
+                        error!(%error, "Unable to ensure if ~/.local/share directory exists.");
+                        "./assets/qrcode".to_string()
+                    }
+                },
+                None => "./assets/qrcode".to_string(),
+            }
+        }
+    })
+    .into()
+}
+
+pub fn assets() -> String {
+    static PATH: OnceLock<String> = OnceLock::new();
+    PATH.get_or_init(|| {
+        if cfg!(debug_assertions) {
+            "./assets".to_string()
+        } else {
+            match home_dir() {
+                Some(home_dir) => match ensure_local_share_dir(&home_dir) {
+                    Ok(_) => home_dir
+                        .join(".local/share/signal_client/assets")
+                        .to_str()
+                        .unwrap_or("./assets")
+                        .to_string(),
+                    Err(error) => {
+                        error!(%error, "Unable to ensure if ~/.local/share directory exists.");
+                        "./assets".to_string()
+                    }
+                },
+                None => "./assets".to_string(),
+            }
+        }
+    })
+    .into()
+}
+
+pub fn accounts_dir() -> String {
+    static PATH: OnceLock<String> = OnceLock::new();
+    PATH.get_or_init(|| {
+        if cfg!(debug_assertions) {
+            "./accounts".to_string()
+        } else {
+            match home_dir() {
+                Some(home_dir) => match ensure_local_share_dir(&home_dir) {
+                    Ok(_) => home_dir
+                        .join(".local/share/signal_client/accounts")
+                        .to_str()
+                        .unwrap_or("./accounts")
+                        .to_string(),
+                    Err(error) => {
+                        error!(%error, "Unable to ensure if ~/.local/share directory exists.");
+                        "./accounts".to_string()
+                    }
+                },
+                None => "./accounts".to_string(),
+            }
+        }
+    })
+    .into()
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -19,21 +19,21 @@ pub fn store() -> String {
     static PATH: OnceLock<String> = OnceLock::new();
     PATH.get_or_init(|| {
         if cfg!(debug_assertions) {
-            "sqlite://store.db".to_string()
+            "sqlite://signal_store.db".to_string()
         } else {
             match home_dir() {
                 Some(home_dir) => match ensure_local_share_dir(&home_dir) {
                     Ok(_) => home_dir
                         .join(".local/share/signal_client/store.db")
                         .to_str()
-                        .unwrap_or("sqlite://store.db")
+                        .unwrap_or("sqlite://signal_store.db")
                         .to_string(),
                     Err(error) => {
                         error!(%error, "Unable to ensure if ~/.local/share directory exists.");
-                        "sqlite://store.db".to_string()
+                        "sqlite://signal_store.db".to_string()
                     }
                 },
-                None => "sqlite://store.db".to_string(),
+                None => "sqlite://signal_store.db".to_string(),
             }
         }
     })
@@ -44,21 +44,21 @@ pub fn qrcode() -> String {
     static PATH: OnceLock<String> = OnceLock::new();
     PATH.get_or_init(|| {
         if cfg!(debug_assertions) {
-            "./assets/qrcode".to_string()
+            "./assets/signal_client/qrcode".to_string()
         } else {
             match home_dir() {
                 Some(home_dir) => match ensure_local_share_dir(&home_dir) {
                     Ok(_) => home_dir
                         .join(".local/share/signal_client/assets/qrcode")
                         .to_str()
-                        .unwrap_or("./assets/qrcode")
+                        .unwrap_or("./assets/signal_client/qrcode")
                         .to_string(),
                     Err(error) => {
                         error!(%error, "Unable to ensure if ~/.local/share directory exists.");
-                        "./assets/qrcode".to_string()
+                        "./assets/signal_client/qrcode".to_string()
                     }
                 },
-                None => "./assets/qrcode".to_string(),
+                None => "./assets/signal_client/qrcode".to_string(),
             }
         }
     })
@@ -69,21 +69,21 @@ pub fn assets() -> String {
     static PATH: OnceLock<String> = OnceLock::new();
     PATH.get_or_init(|| {
         if cfg!(debug_assertions) {
-            "./assets".to_string()
+            "./signal_client/assets".to_string()
         } else {
             match home_dir() {
                 Some(home_dir) => match ensure_local_share_dir(&home_dir) {
                     Ok(_) => home_dir
                         .join(".local/share/signal_client/assets")
                         .to_str()
-                        .unwrap_or("./assets")
+                        .unwrap_or("./signal_client/assets")
                         .to_string(),
                     Err(error) => {
                         error!(%error, "Unable to ensure if ~/.local/share directory exists.");
-                        "./assets".to_string()
+                        "./signal_client/assets".to_string()
                     }
                 },
-                None => "./assets".to_string(),
+                None => "./signal_client/assets".to_string(),
             }
         }
     })
@@ -94,21 +94,21 @@ pub fn accounts_dir() -> String {
     static PATH: OnceLock<String> = OnceLock::new();
     PATH.get_or_init(|| {
         if cfg!(debug_assertions) {
-            "./accounts".to_string()
+            "./signal_client/accounts".to_string()
         } else {
             match home_dir() {
                 Some(home_dir) => match ensure_local_share_dir(&home_dir) {
                     Ok(_) => home_dir
                         .join(".local/share/signal_client/accounts")
                         .to_str()
-                        .unwrap_or("./accounts")
+                        .unwrap_or("./signal_client/accounts")
                         .to_string(),
                     Err(error) => {
                         error!(%error, "Unable to ensure if ~/.local/share directory exists.");
-                        "./accounts".to_string()
+                        "./signal_client/accounts".to_string()
                     }
                 },
-                None => "./accounts".to_string(),
+                None => "./signal_client/accounts".to_string(),
             }
         }
     })

--- a/src/ui/linking.rs
+++ b/src/ui/linking.rs
@@ -13,15 +13,15 @@ use tui_qrcode::{Colors, QrCodeWidget};
 
 use crate::{
     app::{App, UiStatusMessage},
-    paths::QRCODE,
+    paths::{self},
     ui::utils::{centered_rect_fixed_size, render_popup},
 };
 
 /// Renders 50x50 QRCode if it exists in the QRCODE path
 pub fn render_qrcode(frame: &mut Frame, area: Rect) {
-    if Path::new(QRCODE).exists() {
+    if Path::new(&paths::qrcode()).exists() {
         if area.width >= 50 && area.height >= 25 {
-            let url = fs::read_to_string(QRCODE).expect("failed to read from file");
+            let url = fs::read_to_string(paths::qrcode()).expect("failed to read from file");
             let qr_code = QrCode::new(url).expect("Failed to generate QRcode");
             let widget = QrCodeWidget::new(qr_code).colors(Colors::Inverted);
             let qr_area = centered_rect_fixed_size(50, 25, area);


### PR DESCRIPTION
Storage, assets and logs are now placed in `~/.local` if compiled with `--release` flag.